### PR TITLE
chore: Use npm install instead of npm ci

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/setup-node@v3.2.0
         with:
           node-version: '16'
-      - run: npm ci
+      - run: npm install
       - name: Prettier
         run: npm run format
       - name: ESLint


### PR DESCRIPTION
I got the error when I use `npm ci`.

- Error: https://github.com/dev-yakuza/deku-nextjs-boilerplate/runs/6812973572?check_suite_focus=true

So, I decided to use `npm install` instead of `npm ci`.