### PR TITLE
style: Add eslint-plugin-import to check import order

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,25 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "no-console": ["error", { "allow": ["debug", "warn", "error"] }],
-    "@typescript-eslint/no-unused-vars": "error"
+    "@typescript-eslint/no-unused-vars": "error",
+    "import/order": [
+      "error",
+      {
+        "groups": ["builtin", "external", "internal"],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "external",
+            "position": "before"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["react"],
+        "newlines-between": "always",
+        "alphabetize": {
+          "order": "asc",
+          "caseInsensitive": true
+        }
+      }
+    ]
   }
 }

--- a/components/SampleButton/index.stories.tsx
+++ b/components/SampleButton/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { SampleButton } from '.'

--- a/components/SampleButton/index.test.tsx
+++ b/components/SampleButton/index.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+
 import { SampleButton } from './index'
 
 const mockButton = jest.fn()

--- a/components/SampleButton/index.tsx
+++ b/components/SampleButton/index.tsx
@@ -1,6 +1,6 @@
+import styled from '@emotion/styled'
 import { Button } from '@mui/material'
 import type { ButtonProps } from '@mui/material'
-import styled from '@emotion/styled'
 
 const StyledButton = styled(Button, {
   shouldForwardProp: (propName) => propName !== 'backgroundColor',

--- a/components/SampleLocale/index.stories.tsx
+++ b/components/SampleLocale/index.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { SampleLocale } from '.'

--- a/components/SampleLocale/index.test.tsx
+++ b/components/SampleLocale/index.test.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
+
 import { render, screen } from '@testing-library/react'
 import { I18nextProvider } from 'react-i18next'
+
 import i18n from 'utils/i18n'
 
 import { SampleLocale } from './index'

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "cspell": "^6.12.0",
         "eslint": "8.24.0",
         "eslint-config-next": "12.3.1",
+        "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-storybook": "^0.6.4",
         "jest": "^29.1.2",
         "jest-environment-jsdom": "^29.1.2",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "cspell": "^6.12.0",
     "eslint": "8.24.0",
     "eslint-config-next": "12.3.1",
+    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-storybook": "^0.6.4",
     "jest": "^29.1.2",
     "jest-environment-jsdom": "^29.1.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,9 @@
 import '../styles/globals.css'
-import type { AppProps } from 'next/app'
 import { ThemeProvider } from '@mui/material'
-import { theme } from 'utils/theme'
 import { appWithTranslation } from 'next-i18next'
+import type { AppProps } from 'next/app'
+
+import { theme } from 'utils/theme'
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,12 @@
+import { Stack, Button } from '@mui/material'
 import type { NextPage, GetStaticProps } from 'next'
-import Head from 'next/head'
-import styles from 'styles/Home.module.css'
-import { i18n } from 'next-i18next.config'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { Stack, Button } from '@mui/material'
+import Head from 'next/head'
+
 import { SampleLocale } from 'components/SampleLocale'
+import { i18n } from 'next-i18next.config'
+import styles from 'styles/Home.module.css'
 
 const Home: NextPage = () => {
   const { t } = useTranslation()


### PR DESCRIPTION
To check the importing libraries ordering, I added the `eslint-plugin-import`

- https://github.com/import-js/eslint-plugin-import