### PR TITLE
style: Turn off react/react-in-jsx-scope eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
           "caseInsensitive": true
         }
       }
-    ]
+    ],
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/components/SampleButton/index.stories.tsx
+++ b/components/SampleButton/index.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { SampleButton } from '.'

--- a/components/SampleLocale/index.stories.tsx
+++ b/components/SampleLocale/index.stories.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { SampleLocale } from '.'


### PR DESCRIPTION
The `import React from 'react'` is not needed from `React 17`.

- Document: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

So, I turn off the ESLint rule and remove the codes.