### PR TITLE
style: Add consistent-type-imports rule to check import type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
         }
       }
     ],
-    "react/react-in-jsx-scope": "off"
+    "react/react-in-jsx-scope": "off",
+    "@typescript-eslint/consistent-type-imports": "error"
   }
 }

--- a/components/SampleButton/index.stories.tsx
+++ b/components/SampleButton/index.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react'
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { SampleButton } from '.'
 

--- a/components/SampleLocale/index.stories.tsx
+++ b/components/SampleLocale/index.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react'
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { SampleLocale } from '.'
 

--- a/components/organisms/Header/index.stories.tsx
+++ b/components/organisms/Header/index.stories.tsx
@@ -1,4 +1,4 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react'
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
 
 import { Header } from '.'
 


### PR DESCRIPTION
To distinguish the import type and component, I added the `@typescript-eslint/consistent-type-imports` rule.

- Document: https://typescript-eslint.io/rules/consistent-type-imports/