### PR TITLE
refactor: Use MUI styled instead of Emtion styled

### DIFF
--- a/components/SampleButton/index.tsx
+++ b/components/SampleButton/index.tsx
@@ -1,6 +1,6 @@
-import styled from '@emotion/styled'
 import { Button } from '@mui/material'
 import type { ButtonProps } from '@mui/material'
+import { styled } from '@mui/system'
 
 const StyledButton = styled(Button, {
   shouldForwardProp: (propName) => propName !== 'backgroundColor',

--- a/components/organisms/BlogItem/index.tsx
+++ b/components/organisms/BlogItem/index.tsx
@@ -1,5 +1,5 @@
-import styled from '@emotion/styled'
 import { Grid, Typography } from '@mui/material'
+import { styled } from '@mui/system'
 import Link from 'next/link'
 
 const Container = styled(Grid)`


### PR DESCRIPTION
I decided to use the `styled` function of `MUI` instead of the `styled` of `Emotion`.

- Document: https://mui.com/system/styled/